### PR TITLE
Fixes to get gcc built

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,8 @@ gcc_repo_branch =   "gcc-4_7-irix"
 irix_root =         "http://mirror.larbob.org/compilertron/irix-root.6.5.30.tar.bz2"
 binutils =          "https://mirrors.tripadvisor.com/gnu/binutils/binutils-2.17a.tar.bz2"
 
-Target_Base_Box =   "debian/contrib-jessie64"
-Target_Version =    "8.11.0"
+Target_Base_Box =   "debian/contrib-stretch64"
+Target_Version =    "9.6.0"
 RAM_for_VM =        "8016"
 NUM_of_CPUs =       "4"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 # Change these settings to match your environment
 #####
 
-gcc_zip =          "https://github.com/onre/gcc/archive/gcc-4_7-irix.zip"
+gcc_zip =           "https://github.com/onre/gcc/archive/gcc-4_7-irix.zip"
 irix_root =         "http://mirror.larbob.org/compilertron/irix-root.6.5.30.tar.bz2"
 binutils =          "https://mirrors.tripadvisor.com/gnu/binutils/binutils-2.17a.tar.bz2"
 

--- a/ansible/roles/setup/files/build_gcc.sh
+++ b/ansible/roles/setup/files/build_gcc.sh
@@ -12,9 +12,10 @@ export target_configargs="--enable-libstdcxx-threads=no"
 export PATH=/opt/binutils/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 main(){
+    mkdir -p /opt/src/gcc/gcc/doc
     touch /opt/src/gcc/gcc/doc/gcc.info
     cd /opt/src/gcc-build
-    /opt/src/gcc/configure --enable-obsolete --disable-multilib --prefix=/opt/gcc  --with-build-sysroot=/opt/irix-root --target=mips-sgi-irix6.5 --disable-nls --enable-languages=c,c++
+    /opt/src/gcc/gcc-gcc-4_7-irix/configure --enable-obsolete --disable-multilib --prefix=/opt/gcc  --with-build-sysroot=/opt/irix-root --target=mips-sgi-irix6.5 --disable-nls --enable-languages=c,c++
     make
     make install
 }

--- a/ansible/roles/setup/files/build_gcc.sh
+++ b/ansible/roles/setup/files/build_gcc.sh
@@ -8,11 +8,12 @@ export RANLIB_FOR_TARGET="mips-sgi-irix6.5-ranlib"
 export STRIP_FOR_TARGET="mips-sgi-irix6.5-strip"
 export READELF_FOR_TARGET="mips-sgi-irix6.5-readelf"
 export target_configargs="--enable-libstdcxx-threads=no"
+export PATH=/opt/binutils/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 main(){
     touch /opt/src/gcc/gcc/doc/gcc.info
-    cd /opt/src/gcc
-    /opt/src/gcc/configure --enable-obsolete --disable-multilib --prefix=/opt/gcc --target=mips-sgi-irix6.5 --disable-nls --enable-languages=c,c++
+    cd /opt/src/gcc-build
+    /opt/src/gcc/configure --enable-obsolete --disable-multilib --prefix=/opt/gcc  --with-build-sysroot=/opt/irix-root --target=mips-sgi-irix6.5 --disable-nls --enable-languages=c,c++
     make
     make install
 }

--- a/ansible/roles/setup/tasks/setup_gcc.yml
+++ b/ansible/roles/setup/tasks/setup_gcc.yml
@@ -3,6 +3,10 @@
     repo: "{{ gcc_repo }}"
     dest: /opt/src/gcc
     version: "{{ gcc_repo_branch }}"
+- name: create empty gcc-build dir
+  file:
+    path: /opt/src/gcc-build
+    state: directory
 - name: Fetch irix-root
   get_url:
     url: "{{ irix_root }}"

--- a/ansible/roles/setup/tasks/setup_gcc.yml
+++ b/ansible/roles/setup/tasks/setup_gcc.yml
@@ -1,36 +1,43 @@
 - name: Fetch gcc
   get_url:
     url: "{{ gcc_zip }}"
-    dest: /opt/src
+    dest: "/opt/src/gcc-4_7-irix.zip"
+
+- debug:
+    msg: "The next task Extracting gcc will take 10-20 min......."
+
 - name: Extracting gcc
   unarchive:
-    src: "/opt/{{  gcc_zip | urlsplit('path') | basename }}"
-    dest: /opt/src/gcc
-    version: "{{ gcc_repo_branch }}"
+    src: "/opt/src/{{  gcc_zip | urlsplit('path') | basename }}"
+    dest: "/opt/src/gcc"
+    copy: no
+    creates: "/opt/src/gcc/ltgcc.m4"
+
 - name: create empty gcc-build dir
   file:
-    path: /opt/src/gcc-build
-    copy: no
-    creates: /opt/src/gcc/ltgcc.m4
+    path: "/opt/src/gcc-build"
     state: directory
+
 - name: Fetch irix-root
   get_url:
     url: "{{ irix_root }}"
     dest: "/opt/{{  irix_root | urlsplit('path') | basename }}"
+
 - name: create irix-root
   file:
-    path: /opt/irix-root
+    path: "/opt/irix-root"
     state: directory
+
 - name: Extracting irix-root
   unarchive:
     src: "/opt/{{  irix_root | urlsplit('path') | basename }}"
-    dest: /opt/irix-root
+    dest: "/opt/irix-root"
     copy: no
-    creates: /opt/irix-root/usr/lib32/yaccpar
+    creates: "/opt/irix-root/usr/lib32/yaccpar"
 
 - name: Build Fix 1 - 
   file:
-    path: /opt/gcc/mips-sgi-irix6.5
+    path: "/opt/gcc/mips-sgi-irix6.5"
     state: directory
 
 - name: Build Fix 2 - symlink for includes

--- a/ansible/roles/setup/tasks/setup_virt_os.yml
+++ b/ansible/roles/setup/tasks/setup_virt_os.yml
@@ -3,9 +3,9 @@
   hostname: 
     name: compilertron
 
-- apt_repository:
-    repo: deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main
-    state: present
+#- apt_repository:
+#    repo: deb http://ppa.launchpad.net/ansible/ansible/ubuntu devel main
+#    state: present
 
 - name: Add an apt key 
   apt_key:

--- a/ansible/roles/setup/tasks/setup_virt_os.yml
+++ b/ansible/roles/setup/tasks/setup_virt_os.yml
@@ -27,3 +27,4 @@
     - parted
     - texinfo 
     - git 
+    - unzip


### PR DESCRIPTION
Move to debian stretch, numerous fixes to setup tweaks for gcc build to compile and build successfully.