### PR TITLE
NFS finalized, copy hello to NFS, comment out touch in build script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ NUM_of_CPUs =       "2"
 # Set use_nfs to true and put in the host/share and the path where you want it mounted
 # on the VM
 
-use_nfs =         true
+use_nfs =         false
 nfs_host =        "192.168.251.10:/files"
 nfs_path =        "files"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ NUM_of_CPUs =       "2"
 # Set use_nfs to true and put in the host/share and the path where you want it mounted
 # on the VM
 
-use_nfs =         false
+use_nfs =         true
 nfs_host =        "192.168.251.10:/files"
 nfs_path =        "files"
 

--- a/ansible/roles/setup/files/build_gcc.sh
+++ b/ansible/roles/setup/files/build_gcc.sh
@@ -12,8 +12,8 @@ export target_configargs="--enable-libstdcxx-threads=no"
 export PATH=/opt/binutils/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 main(){
-    mkdir -p /opt/src/gcc/gcc/doc
-    touch  /opt/src/gcc/gcc/doc/gcc.info
+    #mkdir -p /opt/src/gcc/gcc/doc
+    #touch  /opt/src/gcc/gcc/doc/gcc.info
     cd /opt/src/gcc-build
     /opt/src/gcc/configure --enable-obsolete --disable-multilib --prefix=/opt/gcc  --with-build-sysroot=/opt/irix-root --target=mips-sgi-irix6.5 --disable-nls --enable-languages=c,c++
     make

--- a/ansible/roles/setup/tasks/main.yml
+++ b/ansible/roles/setup/tasks/main.yml
@@ -2,9 +2,9 @@
 - import_tasks: setup_virt_os.yml
 # Add 50gb opt vol
 - import_tasks: setup_compile_vol.yml
+# setup NFS client to move executables
 # tasks only fire when use_nfs set to true
 - import_tasks: setup_nfs.yml
-
 # Set up gcc
 - import_tasks: setup_gcc.yml
 # build binutils
@@ -13,6 +13,3 @@
 - import_tasks: build_gcc.yml
 # test compiler
 - import_tasks: test_hello.yml
-# setup NFS client to move executables
-# tasks only fire when use_nfs set to true
-- import_tasks: setup_nfs.yml

--- a/ansible/roles/setup/tasks/setup_nfs.yml
+++ b/ansible/roles/setup/tasks/setup_nfs.yml
@@ -5,17 +5,17 @@
 - name: Check if NFS is already setup
   stat:       path=/{{ nfs_path }}
   register:   nfs_path_exists
+  when:     use_nfs
 
 - name: Create mount point for our share
   file:         path=/{{ nfs_path }} state=directory mode=777 owner=root group=root
-  when:         use_nfs
-  when:         not nfs_path_exists.stat.exists
+  when:         use_nfs and not nfs_path_exists.stat.exists      
 
 - name: Mount the share on the VM
   mount: 
     path:       /{{ nfs_path }}
     src:        "{{ nfs_host }}"
     fstype:     nfs
-    opts:       defaults,noatime
+    opts:       defaults,noatime,rw
     state:      mounted
   when:         use_nfs

--- a/ansible/roles/setup/tasks/setup_nfs.yml
+++ b/ansible/roles/setup/tasks/setup_nfs.yml
@@ -1,12 +1,17 @@
 - name: Ensure NFS common is installed.
-  apt: name=nfs-common state=present update_cache=yes
-  when: use_nfs
+  apt:      name=nfs-common state=present update_cache=yes
+  when:     use_nfs
 
-- name: Create mountable dir
-  file: path=/{{ nfs_path }} state=directory mode=777 owner=root group=root
-  when: use_nfs
+- name: Check if NFS is already setup
+  stat:       path=/{{ nfs_path }}
+  register:   nfs_path_exists
 
-- name: set mountpoints
+- name: Create mount point for our share
+  file:         path=/{{ nfs_path }} state=directory mode=777 owner=root group=root
+  when:         use_nfs
+  when:         not nfs_path_exists.stat.exists
+
+- name: Mount the share on the VM
   mount: 
     path:       /{{ nfs_path }}
     src:        "{{ nfs_host }}"

--- a/ansible/roles/setup/tasks/setup_nfs.yml
+++ b/ansible/roles/setup/tasks/setup_nfs.yml
@@ -5,7 +5,7 @@
 - name: Check if NFS is already setup
   stat:       path=/{{ nfs_path }}
   register:   nfs_path_exists
-  when:     use_nfs
+  when:       use_nfs
 
 - name: Create mount point for our share
   file:         path=/{{ nfs_path }} state=directory mode=777 owner=root group=root

--- a/ansible/roles/setup/tasks/test_hello.yml
+++ b/ansible/roles/setup/tasks/test_hello.yml
@@ -28,9 +28,9 @@
 - name: move test file to NFS if available
   copy:
     src:        "/opt/scratch/hello"
-    dest:       "{{ nfs_path }}"
+    dest:       "/{{ nfs_path }}"
     remote_src: yes
     owner:      nobody
-    group:      nobody
+    group:      nogroup
     mode:       0755
   when:         use_nfs

--- a/ansible/roles/setup/tasks/test_hello.yml
+++ b/ansible/roles/setup/tasks/test_hello.yml
@@ -28,7 +28,8 @@
 - name: move test file to NFS if available
   copy:
     src:        "/opt/scratch/hello"
-    dest:       "{{ nfs_path}}"
+    dest:       "{{ nfs_path }}"
+    remote_src: yes
     owner:      nobody
     group:      nobody
     mode:       0755


### PR DESCRIPTION
A few final tweaks for the NFS setup work to ensure -

    it works idempotenly
    fixed double task in main.yml for nfs_setup (copied in 2x)
    hello exec is copied to nfs share if setup.

Commented out the touch and mkdir in build_gcc.sh since the gcc.texi ansible fix resolves that issue and we keep the build script as clean as possible.

