### PR TITLE
New RSE for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,30 +32,30 @@ RUN tar -xvjf /opt/irix-root.6.5.30.tar.bz2 -C /opt/irix-root
 FROM sgug as sgug_srpms
 
 WORKDIR /opt/sgug
-RUN curl -OL https://github.com/sgidevnet/sgug-rse/releases/download/v0.0.4beta/sgug-rse-srpms-0.0.4beta.tar.gz
+RUN curl -OL https://github.com/sgidevnet/sgug-rse/releases/download/v0.0.5beta/sgug-rse-srpms-0.0.5beta.tar.gz
 RUN tar -xvf sgug-rse-srpms*.tar.gz
 
-#-------------------------
+# #-------------------------
 FROM sgug as sgug_binutils
 
 COPY files/make_binutils.sh /opt/sgug/make_binutils.sh
 COPY files/patch_binutils.sh /opt/sgug/patch_binutils.sh
-COPY --from=sgug_srpms /opt/sgug/SRPMS/binutils-2.23.2-24.sgugbeta.src.rpm /opt/sgug/binutils-2.23.2-24.sgugbeta.src.rpm
+COPY --from=sgug_srpms /opt/sgug/SRPMS/binutils-2.23.2-25.sgugbeta.src.rpm /opt/sgug/binutils-2.23.2-25.sgugbeta.src.rpm
 RUN chmod +x /opt/sgug/*.sh && \
-    rpm -Uvh /opt/sgug/binutils-2.23.2-24.sgugbeta.src.rpm && \
+    rpm -Uvh /opt/sgug/binutils-2.23.2-25.sgugbeta.src.rpm && \
     tar xvzf /root/rpmbuild/SOURCES/binutils-2.23.2.tar.gz -C /root/rpmbuild/SOURCES && \
     /opt/sgug/patch_binutils.sh && \
     /opt/sgug/make_binutils.sh
 
 #-------------------------
-FROM  sgug_binutils as sgug_gcc
+FROM sgug_binutils as sgug_gcc
 
 COPY files/patch_gcc.sh /opt/sgug/patch_gcc.sh
 COPY files/build_gcc.sh /opt/sgug/build_gcc.sh
-COPY --from=sgug_srpms /opt/sgug/SRPMS/gcc-9.2.0-1.sgugbeta.src.rpm /opt/sgug/gcc-9.2.0-1.sgugbeta.src.rpm
+COPY --from=sgug_srpms /opt/sgug/SRPMS/gcc-9.2*.sgugbeta.src.rpm /opt/sgug/gcc-9.2.0-1.sgugbeta.src.rpm
 RUN chmod +x /opt/sgug/*.sh && \
     rpm -Uvh /opt/sgug/gcc-9.2.0-1.sgugbeta.src.rpm && \
-    tar xvzf /root/rpmbuild/SOURCES/gcc-9.2.0-20190812.tar.gz -C /root/rpmbuild/SOURCES && \
+    tar xvzf /root/rpmbuild/SOURCES/gcc-9.2*.tar.gz -C /root/rpmbuild/SOURCES && \
     /opt/sgug/patch_gcc.sh && \
     /opt/sgug/build_gcc.sh  
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,21 @@ RUN chmod +x /opt/sgug/entry.sh && \
     ln -s /opt/sgug/bin/mips-sgi-irix6.5-readelf /opt/sgug/mips-sgi-irix6.5/bin/readelf && \
     ln -s /opt/sgug/bin/mips-sgi-irix6.5-size /opt/sgug/mips-sgi-irix6.5/bin/size && \
     ln -s /opt/sgug/bin/mips-sgi-irix6.5-strings /opt/sgug/mips-sgi-irix6.5/bin/strings && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-gcc /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-cc && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-addr2line /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-addr2line && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-c++ /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-c++ && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-c++filt /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-c++filt && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-cpp /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-cpp && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-elfedit /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-elfedit && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-g++ /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-g++ && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-gcc /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-gcc && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-gcc-9.2.0 /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-gcc-9.2.0 && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-gcov /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-gcov && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-gcov-dump /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-gcov-dump && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-gcov-tool /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-gcov-tool && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-readelf /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-readelf && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-size /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-size && \
+    ln -s /opt/sgug/bin/mips-sgi-irix6.5-strings /opt/sgug/mips-sgi-irix6.5/bin/mips-sgi-irix6.5-strings && \
     update-distcc-symlinks
 
 EXPOSE \  


### PR DESCRIPTION
#### Changes
- Updated RSE
- Attempt to fix exit 110 issue

I ran a local test where I tried two build setups. Both built successfully with this image:
- tmux from tarball
- screen from srpms/specs

I noticed that `tmux` would want the distcc server to invoke `cc`, when `rpmbuild` make process used `mips-sgi-irix6.5-cc`. I added an extra set of symlinks to cover both ends. I don't know if my tmux tarball build is incorrect, but I have seen either situation and have toggled back and forth when I noticed the `exit 110` in server logs.

Please try:

```bash
docker build -t compilertron . --no-cache
docker run -p 3632:3632 compilertron
```

Hopefully this works for others without edits.
